### PR TITLE
sctp: update the reproducer with fixes

### DIFF
--- a/sctp/src/sctp_bz2048251_client.c
+++ b/sctp/src/sctp_bz2048251_client.c
@@ -77,6 +77,13 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
+	/* Subscribe to assoc_id events */
+	result = set_subscr_events(sock, off, on, off, off);
+	if (result < 0) {
+		perror("Client setsockopt: SCTP_EVENTS");
+		return 1;
+	}
+
 	result = open_assoc(sock, serverinfo->ai_addr, serverinfo->ai_addrlen,
 			    verbose);
 	if (result) {

--- a/sctp/src/sctp_bz2048251_server.c
+++ b/sctp/src/sctp_bz2048251_server.c
@@ -102,6 +102,13 @@ int main(int argc, char **argv)
 		fclose(f);
 	}
 
+	/* Subscribe to assoc_id events */
+	result = set_subscr_events(sock, off, on, off, off);
+	if (result < 0) {
+		perror("Client setsockopt: SCTP_EVENTS");
+		return 1;
+	}
+
 	result = receive_assoc(sock, &sin, &sinlen, verbose);
 	if (result) {
 		close(sock);

--- a/sctp/src/sctp_peeloff_client.c
+++ b/sctp/src/sctp_peeloff_client.c
@@ -69,6 +69,13 @@ int main(int argc, char **argv)
 		exit(5);
 	}
 
+	/* Subscribe to assoc_id events */
+	result = set_subscr_events(sock, off, on, off, off);
+	if (result < 0) {
+		perror("Client setsockopt: SCTP_EVENTS");
+		return 1;
+	}
+
 	result = open_assoc(sock, serverinfo->ai_addr, serverinfo->ai_addrlen,
 			    verbose);
 	if (result) {

--- a/sctp/src/sctp_peeloff_server.c
+++ b/sctp/src/sctp_peeloff_server.c
@@ -102,6 +102,13 @@ int main(int argc, char **argv)
 		fclose(f);
 	}
 
+	/* Subscribe to assoc_id events */
+	result = set_subscr_events(sock, off, on, off, off);
+	if (result < 0) {
+		perror("Client setsockopt: SCTP_EVENTS");
+		return 1;
+	}
+
 	do {
 		result = receive_assoc(sock, &sin, &sinlen, verbose);
 		if (result) {


### PR DESCRIPTION
This applies fixes and does some refactoring. Basically this just syncs
the code with what we have in our automated test (also derived from the
original reproducer):
https://src.fedoraproject.org/tests/selinux/blob/main/f/kernel/sctp_peer_label_bug